### PR TITLE
Add validate.py

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 rdflib = "*"
 pyyaml = "*"
 PyGithub = "*"
+pyshacl = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "70fff705570c538f83f0919f738e1dfbefb1a4ee2a5659401a8d8d23dde2818a"
+            "sha256": "0ab156e5086188bbcef3497b269564faeacdfc3a40de2a0a67977c8b2d5319b6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -194,6 +194,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.13"
         },
+        "html5lib": {
+            "hashes": [
+                "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d",
+                "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.1"
+        },
         "idna": {
             "hashes": [
                 "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
@@ -208,6 +216,29 @@
                 "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"
             ],
             "version": "==0.6.1"
+        },
+        "owlrl": {
+            "hashes": [
+                "sha256:57eca06b221edbbc682376c8d42e2ddffc99f61e82c0da02e26735592f08bacc",
+                "sha256:904e3310ff4df15101475776693d2427d1f8244ee9a6a9f9e13c3c57fae90b74"
+            ],
+            "version": "==6.0.2"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+                "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.0"
+        },
+        "prettytable": {
+            "hashes": [
+                "sha256:1411c65d21dca9eaa505ba1d041bed75a6d629ae22f5109a923f4e719cfecba4",
+                "sha256:f7da57ba63d55116d65e5acb147bfdfa60dceccabf0d607d6817ee2888a05f2c"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.5.0"
         },
         "pycparser": {
             "hashes": [
@@ -255,6 +286,14 @@
             ],
             "markers": "python_full_version >= '3.6.8'",
             "version": "==3.0.9"
+        },
+        "pyshacl": {
+            "hashes": [
+                "sha256:47f014c52cc69167b902c89b3940dd400f7f5d2169a62f97f837f3419b4a737d",
+                "sha256:5de57ed490748f621301f69e47224fa5bd84b0fb5aab40126118dc8e90d4ede6"
+            ],
+            "index": "pypi",
+            "version": "==0.20.0"
         },
         "pyyaml": {
             "hashes": [
@@ -341,6 +380,20 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.26.14"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e",
+                "sha256:a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0"
+            ],
+            "version": "==0.2.6"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
         },
         "wrapt": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ If you need an absolute path to the script, then just use `/app/<script name.py>
   - current release - version tag for the main ontology
   - repository name - name of the origin repository
   - output path - output directory path
+- `validate.py` – validates the ontology using SHACL. Args:
+  - input dir – the root of the OpenCS

--- a/validate.py
+++ b/validate.py
@@ -1,0 +1,47 @@
+from pyshacl import validate
+from rdflib import Graph
+import sys
+
+import opencs
+
+def main():
+    if len(sys.argv) != 2:
+        print(
+            'Validates the ontology\n'
+            'Args: \n'
+            '- input dir – root of OpenCS repo (no trailing slash)'
+        )
+        exit(1)
+    in_dir = sys.argv[1]
+    process_validate_ontology(in_dir)
+
+def process_validate_ontology(in_dir: str):
+    g = Graph()
+    g.parse(in_dir + '/ontology/header.ttl')
+    opencs.parse_all(g, in_dir + '/ontology/core/**/*.ttl')
+    g.parse(in_dir + '/ontology/authors.ttl')
+    with open(in_dir + '/ontology/shacl_constraints.ttl', encoding='utf8') as f:
+        shacl_text = f.read()
+    validate_shacl(g, shacl_text)
+    
+def validate_shacl(g: Graph, shacl_text: str):
+    report = validate(g,
+        shacl_graph=shacl_text,
+        ont_graph=None,
+        inference=None,
+        abort_on_first=False,
+        allow_infos=False,
+        allow_warnings=False,
+        meta_shacl=False,
+        advanced=False,
+        js=False,
+        debug=False)
+    conforms, results_graph, results_text = report
+    if not conforms:
+        print(results_text)
+        exit(1)
+    else:
+        print('Validated! No issues found!') 
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We add validate.py according to the previous comments. The shacl code is moved to the OpenCS repository. 