### PR TITLE
Dockerfile: use a non-slim Python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim as base
+FROM python:3.10 as base
 
 # Setup env
 ENV LANG C.UTF-8


### PR DESCRIPTION
The slim version does not have utilities like wget that we need.