### PR TITLE
Add the Jena installation and validation script to the CI worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy
 
 FROM base AS runtime
 
+WORKDIR /opt
+RUN wget https://dlcdn.apache.org/jena/binaries/apache-jena-4.10.0.tar.gz -O jena.tar.gz
+RUN mkdir jena
+RUN tar -xzf jena.tar.gz --directory jena --strip-components=1
+RUN rm jena.tar.gz
+
 WORKDIR /app
 # download robot.jar - wrapper for HermiT
 RUN wget https://github.com/ontodev/robot/releases/download/v1.9.1/robot.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 # Install Java Temurin 17 using the official docker image
 ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
+COPY --from=docker.io/eclipse-temurin:17 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Install application into container

--- a/validate_jena.sh
+++ b/validate_jena.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 mkdir package
-/opt/jena/bin/turtle opencs/ontology/core/*/*.ttl > package/core.ttl
+/opt/jena/bin/turtle opencs/ontology/core/*/*.ttl > package/core.ttl 2> package/riot.log
 /opt/jena/bin/shacl validate --shapes opencs/ontology/shacl_constraints.ttl --data package/core.ttl > package/validation_report.ttl
 /opt/jena/bin/sparql --query /app/validation_short_report.rq --data package/validation_report.ttl
 

--- a/validate_jena.sh
+++ b/validate_jena.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+mkdir package
+/opt/jena/bin/turtle opencs/ontology/core/*/*.ttl > package/core.ttl
+/opt/jena/bin/shacl validate --shapes opencs/ontology/shacl_constraints.ttl --data package/core.ttl > package/validation_report.ttl
+/opt/jena/bin/sparql --query /app/validation_short_report.rq --data package/validation_report.ttl
+

--- a/validation_short_report.rq
+++ b/validation_short_report.rq
@@ -1,0 +1,15 @@
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT 
+?validation 
+(IF(COUNT(?viol) = 0, "Success", "Failure" ) as ?validationNonCritical)
+(COUNT(?viol) as ?violations) 
+(COUNT(?warn) as ?warnings) 
+(COUNT(?info) as ?informations) WHERE {
+  bind(IF( exists { ?sub sh:conforms true }, "Success", "Failure") as ?validation)
+  OPTIONAL {?viol sh:resultSeverity  sh:Violation .}
+  OPTIONAL {?warn sh:resultSeverity  sh:Warning .}
+  OPTIONAL {?info sh:resultSeverity  sh:Info . }
+} group by ?validation


### PR DESCRIPTION
This is the first step to resolving https://github.com/OpenCS-ontology/OpenCS/issues/23
It was tested on a forked OpenCS repo: https://github.com/niegrzybkowski/OpenCS.

Dockerfile modifications:
- Jena installation is somewhat messy and unverified
- I needed to add in the docker.io registry because podman doesn't like docker.io

validate_jena.sh
- Mimics functionality of validate.py
- More rigid because I don't want to parse command line arguments in bash
- The file package/validation_report.ttl can be uploaded as a run artifact, but this change needs to be made in the actions of the main repository
- One major disparity to the Python version is that this method **will not fail the action**, but I wasn't sure how to do that in a nice way.

validation_short_report.rq
- This is a sparql query that creates a nice table with the summary of the number of violations, warning and information violations.

I intentionally do not remove the Python version of the validation, but it can be removed once everything else is switched over to Jena.