### PR TITLE
Improve the Jena validation script

### DIFF
--- a/validate_jena.sh
+++ b/validate_jena.sh
@@ -2,5 +2,14 @@
 mkdir package
 /opt/jena/bin/turtle opencs/ontology/core/*/*.ttl > package/core.ttl 2> package/riot.log
 /opt/jena/bin/shacl validate --shapes opencs/ontology/shacl_constraints.ttl --data package/core.ttl > package/validation_report.ttl
-/opt/jena/bin/sparql --query /app/validation_short_report.rq --data package/validation_report.ttl
 
+table=$(/opt/jena/bin/sparql --query /app/validation_short_report.rq --data package/validation_report.ttl)
+echo "$table"
+
+messages=($(echo $table | grep -Eo '^|"([^|])*?"|'))
+
+second=${messages[1]}
+
+if [ $second != '"Success"' ]; then
+        exit 1;
+fi

--- a/validation_short_report.rq
+++ b/validation_short_report.rq
@@ -2,14 +2,21 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT 
-?validation 
-(IF(COUNT(?viol) = 0, "Success", "Failure" ) as ?validationNonCritical)
-(COUNT(?viol) as ?violations) 
-(COUNT(?warn) as ?warnings) 
-(COUNT(?info) as ?informations) WHERE {
+SELECT
+?validation
+(IF(?violations = 0, "Success", "Failure" ) as ?validationNonCritical)
+?violations
+?warnings
+?informations
+WHERE {
   bind(IF( exists { ?sub sh:conforms true }, "Success", "Failure") as ?validation)
-  OPTIONAL {?viol sh:resultSeverity  sh:Violation .}
-  OPTIONAL {?warn sh:resultSeverity  sh:Warning .}
-  OPTIONAL {?info sh:resultSeverity  sh:Info . }
-} group by ?validation
+  {
+    select (count(?viol) as ?violations) where {?viol sh:resultSeverity  sh:Violation .}
+  }
+  {
+    select (count(?warn) as ?warnings) where {?warn sh:resultSeverity  sh:Warning .}
+  }
+  {
+    select (count(?info) as ?informations) where {?info sh:resultSeverity  sh:Info .}
+  }
+}


### PR DESCRIPTION
This PR will address two issues with the previous version of Jena-based SHACL validation (added in https://github.com/OpenCS-ontology/ci-worker/pull/14):

- If a critical violation occurs, the script with exit with an error, displaying an "x" next to the commit.
- The previous query for the small summary table did not work correctly when a violation and a warning occurred at the same time. Hopefully it works now :)
